### PR TITLE
Added possibility to import other configuration files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ The node start script:
 
 At present _node-configure_ only supports JSON configuration files.
 
+## Importing other Files
+
+It is possible to import other configuration files using _node-configure_. This is done by introducing a property called `$import` in the JSON configuration file that accepts an array of paths to other configuration files or a single file path.
+
+This configuration file:
+
+```json
+{
+    "$import" : ["/etc/db/config.json", "{root}/config/eureka.json"]
+}
+```
+
+will import the files `/etc/db/config.json` and `{root}/config/eureka.json` where `{root}` is replaced by the directory of the root configuration file and all paths are treated as absolute paths. Notice that the imported files have a higher priority and may overwrite properties of the root file. Also notice that the imported files can also import other files so you have to take care of not building dependency cycles.
+
+
 #Default Behavior
 
 The first time the _node-configure_ module is required by an application, it will attempt to load the file specified
@@ -107,6 +122,7 @@ to return null when it fails to load a configuration file.
 command line.
 * **commandLineSwitchName**: specifies the command line switch _node-configure_ should look for to determine which
 configuration file to load. Change this value if you or some other module already use `--config`
+* **importProperty**: specified the property in the configuration JSON file that is used to import other configuration files
 
 #Unit Tests
 _node-configure_ features a suite of integration tests that can be run using npm's test script feature:

--- a/install.js
+++ b/install.js
@@ -18,10 +18,16 @@ if(process.env.npm_package_config_commandLineSwitchName) {
     cliSwitch = process.env.npm_package_config_commandLineSwitchName;
 }
 
+var importProperty = "config";
+if(process.env.npm_package_config_importProperty) {
+    importProperty = process.env.npm_package_config_importProperty;
+}
+
 var config = {
     "throwOnError" : throwOnError,
     "defaultConfigFile" : defaultConfigFile,
-    "commandLineSwitchName" : cliSwitch
+    "commandLineSwitchName" : cliSwitch,
+    "importProperty" : importProperty
 };
 
 var fs = require("fs");

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ var _readFile = function(filePath) {
 
     var config;
     try {
-        config = fs.readFileSync(filePath, "utf-8");
+        config = JSON.parse(fs.readFileSync(filePath, "utf-8"));
     } catch (e) {
         var msg = 'Unable to read or parse file "' + path + '". Exception caught: ' + e;
         if(packageConfig.throwOnError) {
@@ -28,19 +28,20 @@ var _readFile = function(filePath) {
         console.error(msg);
         return null;
     }
-    extend(true, result, config);
+    result = extend(true, {}, result, config);
 
     if(result[importProperty]) {
         var imports = (result[importProperty] instanceof Array ? result[importProperty] : [result[importProperty]]);
         delete result[importProperty];
+
         for(var i = 0; i < imports.length; i++) {
-            var import = imports[i];
-            if (typeof import !== 'string') {
-                console.warn('Unsupported import type: "' + (typeof import) + '"! Must be: "string".');
+            var importStr = imports[i];
+            if (typeof importStr !== 'string') {
+                console.warn('Unsupported import type: "' + (typeof importStr) + '"! Must be: "string".');
                 continue;
             }
 
-            var importConfig = _readFile(import.replace("{root}", dirPath));
+            var importConfig = _readFile(importStr.replace("{root}", dirPath));
             if (!importConfig) {
                 // An error occurred whilst parsing the imported configuration. If
                 // throwOnError was set to true, an error was thrown. Otherwise, _readFile
@@ -48,7 +49,7 @@ var _readFile = function(filePath) {
 
                 return null;
             }
-            extend(true, result, importConfig);
+            result = extend(true, {}, result, importConfig);
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -2,28 +2,51 @@
 "use strict";
 
 var packageConfig = require(__dirname + "/package.config.json");
+var importProperty = packageConfig.importProperty;
 var fileName = packageConfig.defaultConfigFile;
 var args = require("optimist").argv;
 var fs = require("fs");
+var extend = require('extend');
 var path = require("path");
 
 if(args[packageConfig.commandLineSwitchName]) {
     fileName = args[packageConfig.commandLineSwitchName];
 }
-var rootDir = process.cwd();
 
-var configData = "";
-var filePath = path.normalize(rootDir) + "/" + fileName;
+var _readFile = function(filePath) {
+    var dirPath = path.dirname(filePath);
+    var result = {};
 
-try {
-    configData = fs.readFileSync(filePath, "utf-8");
-    module.exports = JSON.parse(configData);
-}
-catch(e) {
-    var msg = 'Unable to read or parse file "' + filePath + '". Exception caught: ' + e;
-    if(packageConfig.throwOnError) {
-        throw new Error(msg);
+    var config;
+    try {
+        config = fs.readFileSync(filePath, "utf-8");
+    } catch (e) {
+        var msg = 'Unable to read or parse file "' + path + '". Exception caught: ' + e;
+        if(packageConfig.throwOnError) {
+            throw new Error(msg);
+        }
+        console.error(msg);
+        return null;
     }
-    console.error(msg);
-    module.exports = null;
-}
+    extend(true, result, config);
+
+    if(result[importProperty]) {
+        var imports = (result[importProperty] instanceof Array ? result[importProperty] : [result[importProperty]]);
+        delete result[importProperty];
+        for(var i = 0; i < imports.length; i++) {
+            var importConfig = _readFile(path.join(dirPath, imports[i]));
+            if (!importConfig) {
+                // An error occurred whilst parsing the imported configuration. If
+                // throwOnError was set to true, an error was thrown. Otherwise, _readFile
+                // returned 'null', to check for this and return 'null' again.
+
+                return null;
+            }
+            extend(true, result, importConfig);
+        }
+    }
+
+    return result;
+};
+
+module.exports = _readFile(path.join(path.normalize(process.cwd()), fileName));

--- a/main.js
+++ b/main.js
@@ -34,7 +34,13 @@ var _readFile = function(filePath) {
         var imports = (result[importProperty] instanceof Array ? result[importProperty] : [result[importProperty]]);
         delete result[importProperty];
         for(var i = 0; i < imports.length; i++) {
-            var importConfig = _readFile(path.join(dirPath, imports[i]));
+            var import = imports[i];
+            if (typeof import !== 'string') {
+                console.warn('Unsupported import type: "' + (typeof import) + '"! Must be: "string".');
+                continue;
+            }
+
+            var importConfig = _readFile(import.replace("{root}", dirPath));
             if (!importConfig) {
                 // An error occurred whilst parsing the imported configuration. If
                 // throwOnError was set to true, an error was thrown. Otherwise, _readFile

--- a/package.config.json
+++ b/package.config.json
@@ -1,5 +1,6 @@
 {
     "throwOnError" : "true",
     "defaultConfigFile" : "config.json",
-    "commandLineSwitchName" : "config"
+    "commandLineSwitchName" : "config",
+    "importProperty" : "$import"
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "importProperty" : "$import"
     },
     "dependencies" : {
+        "extend" : "^3.0.0",
         "optimist" : ">=0.3.4"
     },
     "directories" : {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "config" : {
         "notFound" : "throw",
         "defaultConfigFile" : "config.json",
-        "commandLineSwitchName" : "config"
+        "commandLineSwitchName" : "config",
+        "importProperty" : "$import"
     },
     "dependencies" : {
         "optimist" : ">=0.3.4"


### PR DESCRIPTION
These changes enable the user to import other configuration files from their file system using a property called `$import` (the name is configurable) to import one or many other JSON files.

You may lookup the `README.md` for a detailed explanation of how to use this feature.
