### PR TITLE
Added advanced reading for configuration files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 There are several configuration modules available for node.js. Each have their strengths and weaknesses, but
 no one project can be considered the optimal configuration option for all use cases. Some applications have
-need of complex configuration that can be fetched from a central server. Others just want a simple JSON object
-loaded when the app starts.
+need of complex configuration that can be fetched from a central server. Others just want a simple JSON
+object or a simple JavaScript file loaded when the app starts.
 
 _node-configure_ seeks to solve the problem of a single application that is being developed by a group of
 developers who need the ability to have a different application configuration for each developer and deployment environment,
@@ -14,13 +14,17 @@ being forced to worry about overwrites from another developer.
 
 #Overview
 
-_node-configure_ is designed to provide a global config that can be obtained from any node application file without
+_node-configure_ is designed to provide a global configuration that can be obtained from any node application file without
 forcing the main app file to load and pass around configuration setting objects. With _node-configure_, any file or
 module that requires the _node-configure_ module will receive the same configuration object, which is the parsed
-result of the JSON configuration file.
+result of the configuration file.
 
 With _node-configure_, it is the responsibility of modules that wish to obtain configuration settings to know
 their appropriate configuration fields and to provide defaults as necessary.
+
+As _node-configure_ used the `require(..)` mechanism for loading the configuration file, it can either be a simple
+JSON file or a JavaScript file. Notice that JavaScript files have to export a simple JS object in the same object
+as it would be stored in JSON files.
 
 ## Installation
 
@@ -78,9 +82,10 @@ At present _node-configure_ only supports JSON configuration files.
 
 ## Importing other Files
 
-It is possible to import other configuration files using _node-configure_. This is done by introducing a property called `$import` in the JSON configuration file that accepts an array of paths to other configuration files or a single file path.
+It is possible to import other configuration files using _node-configure_. This is done by introducing a property
+called `$import` in the configuration file that accepts an array of paths to other configuration files or a single file path.
 
-This configuration file:
+This configuration file (JSON format):
 
 ```json
 {
@@ -88,7 +93,10 @@ This configuration file:
 }
 ```
 
-will import the files `/etc/db/config.json` and `{root}/config/eureka.json` where `{root}` is replaced by the directory of the root configuration file and all paths are treated as absolute paths. Notice that the imported files have a higher priority and may overwrite properties of the root file. Also notice that the imported files can also import other files so you have to take care of not building dependency cycles.
+will import the files `/etc/db/config.json` and `{root}/config/eureka.json` where `{root}` is replaced by the
+directory of the root configuration file and all paths are treated as absolute paths. Notice that the imported
+files have a higher priority and may overwrite properties of the root file. Also notice that the imported files
+can also import other files so you have to take care of not building dependency cycles.
 
 
 #Default Behavior
@@ -98,7 +106,8 @@ by the `--config` switch relative to the current working directory as obtained v
 _node-configure_ fails to find or load the file, it will throw an exception.
 
 If the `--config` switch is not included as a command line parameter, _node-configure_ will attempt to load the file
-"config.json" in the current working directory. If that file is not found, _node-configure_ will throw an exception.
+"config.js" or "config.json" in the current working directory. If that file is not found, _node-configure_ will
+throw an exception.
 
 #Changing Default Behavior
 
@@ -122,7 +131,7 @@ to return null when it fails to load a configuration file.
 command line.
 * **commandLineSwitchName**: specifies the command line switch _node-configure_ should look for to determine which
 configuration file to load. Change this value if you or some other module already use `--config`
-* **importProperty**: specified the property in the configuration JSON file that is used to import other configuration files
+* **importProperty**: specified the property in the configuration file that is used to import other configuration files
 
 #Unit Tests
 _node-configure_ features a suite of integration tests that can be run using npm's test script feature:
@@ -131,4 +140,4 @@ _node-configure_ features a suite of integration tests that can be run using npm
 
 Because the test script exercises _node-configure_'s ability to use npm package configuration settings, 
 it is important to note that any previously existing configuration settings will be removed as the test
-executes. After test completion, the default package configuration will be set. 
+executes. After test completion, the default package configuration will be set.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ The node start script:
 
 At present _node-configure_ only supports JSON configuration files.
 
+## Importing other Files
+
+It is possible to import other configuration files using _node-configure_. This is done by introducing a property called `$import` in the JSON configuration file that accepts an array of paths to other configuration files or a single file path.
+
+This configuration file:
+
+```json
+{
+    "$import" : ["/etc/db/config.json", "{root}/config/eureka.json"]
+}
+```
+
+will import the files `/etc/db/config.json` and `{root}/config/eureka.json` where `{root}` is replaced by the directory of the root configuration file and all paths are treated as absolute paths. Notice that the imported files have a higher priority and may overwrite properties of the root file. Also notice that the imported files can also import other files so you have to take care of not building dependency cycles.
+
+
 #Default Behavior
 
 The first time the _node-configure_ module is required by an application, it will attempt to load the file specified
@@ -107,6 +122,7 @@ to return null when it fails to load a configuration file.
 command line.
 * **commandLineSwitchName**: specifies the command line switch _node-configure_ should look for to determine which
 configuration file to load. Change this value if you or some other module already use `--config`
+* **importProperty**: specified the property in the configuration JSON file that is used to import other configuration files
 
 #Unit Tests
 _node-configure_ features a suite of integration tests that can be run using npm's test script feature:

--- a/install.js
+++ b/install.js
@@ -8,7 +8,7 @@ if(notFound === "throw") {
     throwOnError = true;
 }
 
-var defaultConfigFile = "config.json";
+var defaultConfigFile = "config";
 if(process.env.npm_package_config_defaultConfigFile) {
     defaultConfigFile = process.env.npm_package_config_defaultConfigFile;
 }

--- a/install.js
+++ b/install.js
@@ -18,10 +18,16 @@ if(process.env.npm_package_config_commandLineSwitchName) {
     cliSwitch = process.env.npm_package_config_commandLineSwitchName;
 }
 
+var importProperty = "config";
+if(process.env.npm_package_config_importProperty) {
+    importProperty = process.env.npm_package_config_importProperty;
+}
+
 var config = {
     "throwOnError" : throwOnError,
     "defaultConfigFile" : defaultConfigFile,
-    "commandLineSwitchName" : cliSwitch
+    "commandLineSwitchName" : cliSwitch,
+    "importProperty" : importProperty
 };
 
 var fs = require("fs");

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ var _readFile = function(filePath) {
 
     var config;
     try {
-        config = fs.readFileSync(filePath, "utf-8");
+        config = JSON.parse(fs.readFileSync(filePath, "utf-8"));
     } catch (e) {
         var msg = 'Unable to read or parse file "' + path + '". Exception caught: ' + e;
         if(packageConfig.throwOnError) {
@@ -28,19 +28,20 @@ var _readFile = function(filePath) {
         console.error(msg);
         return null;
     }
-    extend(true, result, config);
+    result = extend(true, {}, result, config);
 
     if(result[importProperty]) {
         var imports = (result[importProperty] instanceof Array ? result[importProperty] : [result[importProperty]]);
         delete result[importProperty];
+
         for(var i = 0; i < imports.length; i++) {
-            var import = imports[i];
-            if (typeof import !== 'string') {
-                console.warn('Unsupported import type: "' + (typeof import) + '"! Must be: "string".');
+            var importStr = imports[i];
+            if (typeof importStr !== 'string') {
+                console.warn('Unsupported import type: "' + (typeof importStr) + '"! Must be: "string".');
                 continue;
             }
 
-            var importConfig = _readFile(import.replace("{root}", dirPath));
+            var importConfig = _readFile(importStr.replace("{root}", dirPath));
             if (!importConfig) {
                 // An error occurred whilst parsing the imported configuration. If
                 // throwOnError was set to true, an error was thrown. Otherwise, _readFile
@@ -48,7 +49,7 @@ var _readFile = function(filePath) {
 
                 return null;
             }
-            extend(true, result, importConfig);
+            result = extend(true, {}, result, importConfig);
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ var _readFile = function(filePath) {
 
     var config;
     try {
-        config = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+        config = require(filePath);
     } catch (e) {
         var msg = 'Unable to read or parse file "' + path + '". Exception caught: ' + e;
         if(packageConfig.throwOnError) {

--- a/main.js
+++ b/main.js
@@ -2,28 +2,51 @@
 "use strict";
 
 var packageConfig = require(__dirname + "/package.config.json");
+var importProperty = packageConfig.importProperty;
 var fileName = packageConfig.defaultConfigFile;
 var args = require("optimist").argv;
 var fs = require("fs");
+var extend = require('extend');
 var path = require("path");
 
 if(args[packageConfig.commandLineSwitchName]) {
     fileName = args[packageConfig.commandLineSwitchName];
 }
-var rootDir = process.cwd();
 
-var configData = "";
-var filePath = path.normalize(rootDir) + "/" + fileName;
+var _readFile = function(filePath) {
+    var dirPath = path.dirname(filePath);
+    var result = {};
 
-try {
-    configData = fs.readFileSync(filePath, "utf-8");
-    module.exports = JSON.parse(configData);
-}
-catch(e) {
-    var msg = 'Unable to read or parse file "' + filePath + '". Exception caught: ' + e;
-    if(packageConfig.throwOnError) {
-        throw new Error(msg);
+    var config;
+    try {
+        config = fs.readFileSync(filePath, "utf-8");
+    } catch (e) {
+        var msg = 'Unable to read or parse file "' + path + '". Exception caught: ' + e;
+        if(packageConfig.throwOnError) {
+            throw new Error(msg);
+        }
+        console.error(msg);
+        return null;
     }
-    console.error(msg);
-    module.exports = null;
-}
+    extend(true, result, config);
+
+    if(result[importProperty]) {
+        var imports = (result[importProperty] instanceof Array ? result[importProperty] : [result[importProperty]]);
+        delete result[importProperty];
+        for(var i = 0; i < imports.length; i++) {
+            var importConfig = _readFile(path.join(dirPath, imports[i]));
+            if (!importConfig) {
+                // An error occurred whilst parsing the imported configuration. If
+                // throwOnError was set to true, an error was thrown. Otherwise, _readFile
+                // returned 'null', to check for this and return 'null' again.
+
+                return null;
+            }
+            extend(true, result, importConfig);
+        }
+    }
+
+    return result;
+};
+
+module.exports = _readFile(path.join(path.normalize(process.cwd()), fileName));

--- a/main.js
+++ b/main.js
@@ -34,7 +34,13 @@ var _readFile = function(filePath) {
         var imports = (result[importProperty] instanceof Array ? result[importProperty] : [result[importProperty]]);
         delete result[importProperty];
         for(var i = 0; i < imports.length; i++) {
-            var importConfig = _readFile(path.join(dirPath, imports[i]));
+            var import = imports[i];
+            if (typeof import !== 'string') {
+                console.warn('Unsupported import type: "' + (typeof import) + '"! Must be: "string".');
+                continue;
+            }
+
+            var importConfig = _readFile(import.replace("{root}", dirPath));
             if (!importConfig) {
                 // An error occurred whilst parsing the imported configuration. If
                 // throwOnError was set to true, an error was thrown. Otherwise, _readFile

--- a/package.config.json
+++ b/package.config.json
@@ -1,6 +1,6 @@
 {
     "throwOnError" : "true",
-    "defaultConfigFile" : "config.json",
+    "defaultConfigFile" : "config",
     "commandLineSwitchName" : "config",
     "importProperty" : "$import"
 }

--- a/package.config.json
+++ b/package.config.json
@@ -1,5 +1,6 @@
 {
     "throwOnError" : "true",
     "defaultConfigFile" : "config.json",
-    "commandLineSwitchName" : "config"
+    "commandLineSwitchName" : "config",
+    "importProperty" : "$import"
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "importProperty" : "$import"
     },
     "dependencies" : {
+        "extend" : "^3.0.0",
         "optimist" : ">=0.3.4"
     },
     "directories" : {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "config" : {
         "notFound" : "throw",
         "defaultConfigFile" : "config.json",
-        "commandLineSwitchName" : "config"
+        "commandLineSwitchName" : "config",
+        "importProperty" : "$import"
     },
     "dependencies" : {
         "optimist" : ">=0.3.4"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "config" : {
         "notFound" : "throw",
-        "defaultConfigFile" : "config.json",
+        "defaultConfigFile" : "config",
         "commandLineSwitchName" : "config",
         "importProperty" : "$import"
     },


### PR DESCRIPTION
Until now it was only possible to load JSON configuration files which are completely static. With this update, it is possible to load JavaScript files as they are loading using Node's `require()` mechanism.

CAUTION: If you have a `config.js` in your working directory, it will be loaded instead of the `config.json`! You have to manually set `defaultConfigFile` to `config.json` using `npm config set configure:defaultConfigFile config.json` to load the JSON file instead.
